### PR TITLE
Add v1 message wrapper

### DIFF
--- a/x8.md
+++ b/x8.md
@@ -8,27 +8,30 @@ created: 2019-04-22
 updated:
 ---
 
-- [Payload](#Payload)
+- [Wrapper](#Wrapper)
 - [Encoding](#Encoding)
-- [Content types](#Content-types)
-- [Message types](#Message-types)
-- [Clock vs Timestamp and message ordering](#Clock-vs-Timestamp-and-message-ordering)
-- [Replies](#Replies)
 - [Upgradability](#Upgradability)
 
 This specification describes how the payload of each message in the Status Protocol looks like. It does not care how the payload is encrypted or exchanged later.
 
 The payload must be flexible enough to support messenging but also cases described in [Status Whitepaper](https://status.im/whitepaper.pdf) as well as various clients created using vastly different technologies.
 
-# Payload
+# Wrapper
 
-Payload is a struct (a compound data type) with the following fields (order is importent):
-1. text `string`
-2. content type `enum` (more in [Content types](#content-types))
-3. message type `enum` (more in [Message types](#message-types))
-4. clock `int64`
-5. timestamp `int64`
-6. content `struct { chat-id string, text string }`
+Payloads are wrapped in a [protobuf record](https://developers.google.com/protocol-buffers/)
+record:
+
+```
+    message StatusProtocolMessage {
+      bytes signature = 1;
+      bytes payload = 2;
+    }
+```
+
+Where `signature` is the bytes of the signed `SHA3-256` of the payload, signed with
+the key of the author of the message.
+The signature is needed to validate authorship of the message, so that the message can be relayed to third parties.
+If a signature is not present but an author is provided by a layer below, the message is to be relayed to third parties and it's considered plausibly deniable.
 
 # Encoding
 
@@ -46,7 +49,32 @@ As you can see, the message is an array and each index value has its meaning:
 
 For more details regarding serialization and deserialization please consult [transit format](https://github.com/cognitect/transit-format) specification.
 
-# Content types
+# Message types
+
+- [Message](##Message)
+
+## Message
+
+The type `Message` represents a text message exchanged between clients.
+
+- [Payload](###Payload)
+- [Content types](###Content-types)
+- [Message types](###Message-types)
+- [Clock vs Timestamp and message ordering](###Clock-vs-Timestamp-and-message-ordering)
+- [Replies](###Replies)
+
+### Payload
+
+Payload is a struct (a compound data type) with the following fields (order is importent):
+1. text `string`
+2. content type `enum` (more in [Content types](#content-types))
+3. message type `enum` (more in [Message types](#message-types))
+4. clock `int64`
+5. timestamp `int64`
+6. content `struct { chat-id string, text string }`
+
+
+### Content types
 
 Content types are required for a proper interpretation of incoming messaages. Not each message is a plain text but may carry a different information.
 
@@ -60,7 +88,7 @@ There are also other content types that MAY be implemented by the client:
 * `command-request` TODO
 * `emoji` TODO
 
-# Message types
+### Message types
 
 Message types are required to decide how a particular message is encrypted (more in [Whisper > Message encryption](#message-encryption)) and what metadata needs to be attacjed (more in [Whisper > Topic](#topic)) when passing a message to the transport layer.
 
@@ -69,7 +97,7 @@ The following messages types MUST be supported:
 * `user-message` is a private message
 * `group-user-message` is a message to the private group.
 
-# Clock vs Timestamp and message ordering
+### Clock vs Timestamp and message ordering
 
 `timestamp` MUST be Unix time calculated when the message is created. Because the peers in the Whisper network should have synchronized time, `timestamp` values should be fairly accurate among all Whisper network participants.
 
@@ -77,7 +105,7 @@ The following messages types MUST be supported:
 
 `clock` value is used for the message ordering. Due to the used algorithm and distributed nature of the system, we achieve casual ordering which might produce counterintuitive results in some edge cases. For example, when one joins a public chat and sends a message before receiving the exist messages, their message `clock` value might be lower and the message will end up in the past when the historical messages are fetched.
 
-# Replies
+### Replies
 
 TODO
 


### PR DESCRIPTION
Adds the message wrapper from https://github.com/status-im/status-protocol-go/pull/19

I have also restructured `x8` as `Message` is only one type of messages exchanged by the app, there`s more that needs describing: `PairInstallation`, `SyncInstallation`, `ContactRequest`, `ContactUpdate` and a few more.