### PR TITLE
Fix: Mailserver knows the bloomfilter of the topic

### DIFF
--- a/status-client-spec.md
+++ b/status-client-spec.md
@@ -285,7 +285,7 @@ For some further investigation, see
 
 #### I heard something about mailservers being trusted somehow?
 
-In order to use a mail server, a given node needs to connect to it directly, i.e. add the mailserver as its peer and mark it as trusted. This means that the mail server is able to send direct p2p messages to the node instead of broadcasting them. Effectively, it knows which topics the node is interested in, when it is online as well as many metadata like IP address.
+In order to use a mail server, a given node needs to connect to it directly, i.e. add the mailserver as its peer and mark it as trusted. This means that the mail server is able to send direct p2p messages to the node instead of broadcasting them. Effectively, it knows the bloom filter of the topics the node is interested in, when it is online as well as many metadata like IP address.
 
 ### Data sync
 


### PR DESCRIPTION
Nodes only disclose the cumulative bloom filter of the topics they are interested in, not the actual topics.