### PR TITLE
Request contains encrypted data instead of signed

### DIFF
--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -71,7 +71,7 @@ For a requester, to know that all messages have been sent by mailserver, it SHOU
 `LastEnvelopeHash`: 32-byte wide array with a Keccak-256 hash of the last sent envelope for the request  
 `Cursor`: an array of a cursor returned from the previous request (optional)
 
-If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of the messages.
+If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in order to receive the rest of the messages.
 
 ## Security considerations
 

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -51,7 +51,7 @@ In the Whisper envelope's payload section, there MUST be RLP-encoded information
 
 The `Cursor` field SHOULD be filled in if a number of envelopes between `Lower` and `Upper` is greater than `Limit` so that the requester can send another request using the obtained `Cursor` value. What exactly is in the `Cursor` is up to the implementation. The requester SHOULD NOT use a `Cursor` obtained from one mailserver in a request to another mailserver because the format or the result MAY be different.
 
-The envelope MUST be signed with a symmetric key agreed between the requester and Mailserver.
+The envelope MUST be encrypted with a symmetric key agreed between the requester and Mailserver.
 
 ### Receiving historic messages
 

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -67,8 +67,8 @@ For a requester, to know that all messages have been sent by mailserver, it SHOU
 [ RequestID, LastEnvelopeHash, Cursor ]
 ```
 
-`RequestID`: 32-byte wide array with a hash of the envelope containing the original request  
-`LastEnvelopeHash`: 32-byte wide array with a hash of the last sent envelope for the request  
+`RequestID`: 32-byte wide array with a Keccak-256 hash of the envelope containing the original request  
+`LastEnvelopeHash`: 32-byte wide array with a Keccak-256 hash of the last sent envelope for the request  
 `Cursor`: an array of a cursor returned from the previous request (optional)
 
 If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of the messages.

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -61,7 +61,7 @@ In order to receive historic messages from a mailserver, a node MUST trust the s
 
 Received envelopes MUST be passed through the Whisper envelope pipelines so that they are picked up by registered filters and passed to subscribers.
 
-For a requester, to know that all messages have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by a list with:
+For a requester, to know that all messages have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by the following parameters:
 
 ```
 [ RequestID, LastEnvelopeHash, Cursor ]

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -43,10 +43,10 @@ In the Whisper envelope's payload section, there MUST be RLP-encoded information
 [ Lower, Upper, Bloom, Limit, Cursor ]
 ```
 
-`Lower`: 4-byte wide unsigned integer (UNIX time in seconds; oldest requested envelope's creation time)
-`Upper`: 4-byte wide unsigned integer (UNIX time in seconds; newest requested envelope's creation time)
-`Bloom`: 64-byte wide array of Whisper topics encoded in a bloom filter to filter envelopes
-`Limit`: 4-byte wide unsigned integer limiting the number of returned envelopes
+`Lower`: 4-byte wide unsigned integer (UNIX time in seconds; oldest requested envelope's creation time)  
+`Upper`: 4-byte wide unsigned integer (UNIX time in seconds; newest requested envelope's creation time)  
+`Bloom`: 64-byte wide array of Whisper topics encoded in a bloom filter to filter envelopes  
+`Limit`: 4-byte wide unsigned integer limiting the number of returned envelopes  
 `Cursor`: an array of a cursor returned from the previous request (optional)
 
 The `Cursor` field SHOULD be filled in if a number of envelopes between `Lower` and `Upper` is greater than `Limit` so that the requester can send another request using the obtained `Cursor` value. What exactly is in the `Cursor` is up to the implementation. The requester SHOULD NOT use a `Cursor` obtained from one mailserver in a request to another mailserver because the format or the result MAY be different.
@@ -59,19 +59,19 @@ Historic messages MUST be sent to a peer as a packet with a P2P Message code (`0
 
 In order to receive historic messages from a mailserver, a node MUST trust the selected mailserver, that is allow to receive packets with the P2P Message code. By default, such packets are discarded.
 
-Received envelopes MUST be passed through the Whisper envelopes pipelines so that they are picked up by registered filters and passed to subscribers.
+Received envelopes MUST be passed through the Whisper envelope pipelines so that they are picked up by registered filters and passed to subscribers.
 
-For a requester, to know that all messages have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by a a byte array with:
+For a requester, to know that all messages have been sent by mailserver, it SHOULD handle P2P Request Complete code (`0x7d`). This code is followed by a list with:
 
 ```
 [ RequestID, LastEnvelopeHash, Cursor ]
 ```
 
-`RequestID`: 32-byte wide array with a hash of the envelope containing request details
-`LastEnvelopeHash`: 32-byte wide array with a has of the last set envelope for the request
+`RequestID`: 32-byte wide array with a hash of the envelope containing the original request  
+`LastEnvelopeHash`: 32-byte wide array with a hash of the last sent envelope for the request  
 `Cursor`: an array of a cursor returned from the previous request (optional)
 
-If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of messages.
+If `Cursor` is not empty, it means that not all messages were sent due to the set `Limit` in the request. One or more consecutive requests MAY be sent with `Cursor` field filled in in order to receive the rest of the messages.
 
 ## Security considerations
 


### PR DESCRIPTION
Noticed it was saying signed instead of encrypted.
Unless it was meant to say signed asymmetric. 
