### PR TITLE
Move Status EIPs to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Every spec has its own lifecycle that shows its maturity. We indicate this in a 
 
 ### Stable
 
-No stable specs right now. De facto a lot of the draft ones are stable and indicating this is work in progress.
+The following SIPs are stable and running in production.
+
+- [Status EIPs Standards](status-EIPs.md). Ethereum Improvement Proposals used in Status.
 
 ### Draft
 
@@ -25,7 +27,6 @@ The following SIPs are under consideration for standardization.
 - [Status Account Specification](status-account-spec.md). What a Status account is and how trust is established.
 - [Status Whisper Usage Specification](status-whisper-usage-spec.md). How we use Whisper to do routing, metadata protection and provide 1:1/group/public chat.
 - [Status Whisper Mailserver Specification](status-whisper-mailserver-spec.md). How we use Whisper mailservers to provide offline inboxing.
-- [Status EIPs Standards](status-EIPs.md). Ethereum Improvement Proposals used in Status.
 
 ### Raw
 

--- a/status-EIPs.md
+++ b/status-EIPs.md
@@ -1,6 +1,8 @@
 # Status EIPs standards 
 
-> Version: 0.1 (Draft)
+> Version: 0.2
+>
+> Status: Stable
 >
 > Authors: Ricardo Guilherme Schmidt <ricardo3@status.im>
 


### PR DESCRIPTION
This PR moves EIPs spec from draft to stable. This means it is an accurate description of what is currently in production for the v1 app.

If we want to do wider changes in the future these should come in the form of SIP issues and PRs, as indicated in the README.

Changes to this spec can still occur but they should be cocsmetic ones, errata and clarifications.

Please review with anything factually incorrect or add any relevant data. I want to get this merged over the next 24-48h. This will ensure we have a stable set of specs that accurately reflects what is in production, and then we can proceed from there.