### PR TITLE
Move Whisper Mailserver Usage to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ The following SIPs are stable and running in production.
 
 - [Status Secure Transport Specification](status-secure-transport-spec.md). How Status provide a secure transport with conversational security properties.
 
+- [Status Whisper Mailserver Specification](status-whisper-mailserver-spec.md). How we use Whisper mailservers to provide offline inboxing.
+
+- [Status EIPs Standards](status-EIPs.md). Ethereum Improvement Proposals used in Status.
+
 ### Draft
 
 The following SIPs are under consideration for standardization.
@@ -27,7 +31,6 @@ The following SIPs are under consideration for standardization.
 - [Status Payload Specification](status-payloads-spec.md). What the message payloads look like.
 - [Status Account Specification](status-account-spec.md). What a Status account is and how trust is established.
 - [Status Whisper Usage Specification](status-whisper-usage-spec.md). How we use Whisper to do routing, metadata protection and provide 1:1/group/public chat.
-- [Status Whisper Mailserver Specification](status-whisper-mailserver-spec.md). How we use Whisper mailservers to provide offline inboxing.
 
 ### Raw
 

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -1,5 +1,7 @@
 # Status Whisper Mailserver Specification
-> Version: 0.1 (Draft)
+> Version: 0.2
+>
+> Status: Stable
 >
 > Authors: Adam Babik <adam@status.im>, Oskar Thorén <oskar@status.im> (alphabetical order)
 

--- a/status-whisper-mailserver-spec.md
+++ b/status-whisper-mailserver-spec.md
@@ -87,7 +87,7 @@ In order to be useful, a mailserver SHOULD be online most of time. That means
 you either have to be a bit tech-savvy to run your own node, or rely on someone
 else to run it for you.
 
-Currently Status Gmbh provides mailservers in an altruistic manner, but this is
+Currently one of Status's legal entities provides mailservers in an altruistic manner, but this is
 suboptimal from a decentralization, continuance and risk point of view. Coming
 up with a better system for this is ongoing research.
 
@@ -98,8 +98,9 @@ A Status client SHOULD allow the mailserver selection to be customizable.
 In order to use a Mailserver, a given node needs to connect to it directly,
 i.e. add the Mailserver as its peer and mark it as trusted. This means that the
 Mailserver is able to send direct p2p messages to the node instead of
-broadcasting them. Effectively, it knows which topics the node is interested in,
-when it is online as well as many metadata like IP address.
+broadcasting them. Effectively, it will have access to the bloom filter of
+topics that the user is interested in, when it is online as well as many
+metadata like IP address.
 
 ### Denial-of-service
 


### PR DESCRIPTION
This PR moves mailserver spec from draft to stable. This means it is an accurate description of what is currently in production for the v1 app.

If we want to do wider changes in the future these should come in the form of SIP issues and PRs, as indicated in the README.

Changes to this spec can still occur but they should be cosmetic ones, errata and clarifications.

Please review with anything factually incorrect or add any relevant data. I want to get this merged over the next 24-48h. This will ensure we have a stable set of specs that accurately reflects what is in production, and then we can proceed from there.