### PR TITLE
Move Whisper Usage to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following SIPs are stable and running in production.
 
 - [Status EIPs Standards](status-EIPs.md). Ethereum Improvement Proposals used in Status.
 
+- [Status Whisper Usage Specification](status-whisper-usage-spec.md). How we use Whisper to do routing, metadata protection and provide 1:1/group/public chat.
+
 ### Draft
 
 The following SIPs are under consideration for standardization.
@@ -30,7 +32,6 @@ The following SIPs are under consideration for standardization.
 - [Status Client Specification](status-client-spec.md). The main specification for writing a Status client. **Start here**
 - [Status Payload Specification](status-payloads-spec.md). What the message payloads look like.
 - [Status Account Specification](status-account-spec.md). What a Status account is and how trust is established.
-- [Status Whisper Usage Specification](status-whisper-usage-spec.md). How we use Whisper to do routing, metadata protection and provide 1:1/group/public chat.
 
 ### Raw
 

--- a/status-whisper-usage-spec.md
+++ b/status-whisper-usage-spec.md
@@ -284,9 +284,9 @@ One-to-one messages are encrypted using asymmetric encryption.
 
 ## Message confirmations
 
-Sending a message is a complex process where many things can go wrong. Message confirmations tell a node that a message originating from it has been received by its peers.
+Sending a message is a complex process where many things can go wrong. Message confirmations tell a node that a message originating from it has been seen by its direct peers.
 
-A node MAY send a message confirmation for any batch of messages received with a packet Messages Code (`0x01`).
+A node MAY send a message confirmation for any batch of messages received in a packet Messages Code (`0x01`).
 
 A message confirmation is sent using Batch Acknowledge packet (`0x0b`) or Message Response packet (`0x0c`).
 
@@ -303,7 +303,9 @@ The Message Response packet is more complex and is followed by a Versioned Messa
 The supported codes:
 `1`: means time sync error which happens when an envelope is too old or created in the future (the root cause is no time sync between nodes).
 
-The drawback of sending message confirmations is that it increases the noise in the network because for each sent message, a corresponding confirmation is broadcasted by one or more peers.
+The drawback of sending message confirmations is that it increases the noise in the network because for each sent message, a corresponding confirmation is broadcasted by one or more peers. To limit that, both Batch Acknowledge packet (`0x0b`) and Message Response packet (`0x0c`) are not broadcasted to peers of the peers, i.e. they do not follow epidemic spread.
+
+In the current Status network setup, only Mailservers support message confirmations. A client posting a message to the network and after receiving a confirmation can be sure that the message got processed by the Mailserver. If additionally, sending a message is limited to non-Mailserver peers, it also guarantees that the message got broadcasted through the network and it reached the selected Mailserver.
 
 ## Whisper V6 extensions
 

--- a/status-whisper-usage-spec.md
+++ b/status-whisper-usage-spec.md
@@ -1,6 +1,8 @@
 # Status Whisper Usage Specification
 
-> Version: 0.1 (Draft)
+> Version: 0.2
+>
+> Status: Stable
 >
 > Authors: Adam Babik <adam@status.im>, Corey Petty <corey@status.im>, Oskar Thorén <oskar@status.im> (alphabetical order)
 
@@ -62,10 +64,10 @@ encryption properties to support asynchronous chat.
 | Messages | 1 | ✔ | [EIP-627](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-627.md) |
 | PoW Requirement | 2 | ✔ | [EIP-627](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-627.md) |
 | Bloom Filter | 3 | ✔ | [EIP-627](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-627.md) |
-| Batch Ack | 11 | 𝘅 | TODO |
-| Message Response | 12 | 𝘅 | TODO |
-| P2P Sync Request | 123 | 𝘅 | TODO |
-| P2P Sync Response | 124 | 𝘅 | TODO |
+| Batch Ack | 11 | 𝘅 | Undocumented |
+| Message Response | 12 | 𝘅 | Undocumented |
+| P2P Sync Request | 123 | 𝘅 | Undocumented |
+| P2P Sync Response | 124 | 𝘅 | Undocumented |
 | P2P Request Complete | 125 | 𝘅 | [Status Whisper Mailserver Spec](status-whisper-mailserver-spec.md) |
 | P2P Request | 126 | ✔ | [Status Whisper Mailserver Spec](status-whisper-mailserver-spec.md) |
 | P2P Messages | 127 | ✔/𝘅 (EIP-627 supports only single envelope in a packet) | [Status Whisper Mailserver Spec](status-whisper-mailserver-spec.md) |

--- a/status-whisper-usage-spec.md
+++ b/status-whisper-usage-spec.md
@@ -272,6 +272,7 @@ To exchange messages with client B, a client A SHOULD:
 - Listen to client's B Contact Code Topic to retrieve their bundle information, including a list of active devices
 - Send a message on client's B partitioned topic
 - Listen to the Negotiated Topic between A & B
+- Once a message is received from B, the Negotiated Topic SHOULD be used
 
 ## Message encryption
 


### PR DESCRIPTION
This PR moves whisper usage spec from draft to stable. This means it is an accurate description of what is currently in production for the v1 app.

If we want to do wider changes in the future these should come in the form of SIP issues and PRs, as indicated in the README.

Changes to this spec can still occur but they should be cosmetic ones, errata and clarifications.

Please review with anything factually incorrect or add any relevant data. I want to get this merged over the next 24-48h. This will ensure we have a stable set of specs that accurately reflects what is in production, and then we can proceed from there.

---

Concretely, for Waku, this means we'll have another spec that supplants this one and mentions Waku for 1.2 release. Current I'd characterize this as in draft mode, and it'd be in stable mode once it is shipped in a production build in the core client.

When the time is right this spec will be deprecated.