### PR TITLE
Move Account to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,14 @@ The following SIPs are stable and running in production.
 
 - [Status Whisper Usage Specification](status-whisper-usage-spec.md). How we use Whisper to do routing, metadata protection and provide 1:1/group/public chat.
 
+- [Status Account Specification](status-account-spec.md). What a Status account is and how trust is established.
+
 ### Draft
 
 The following SIPs are under consideration for standardization.
 
 - [Status Client Specification](status-client-spec.md). The main specification for writing a Status client. **Start here**
 - [Status Payload Specification](status-payloads-spec.md). What the message payloads look like.
-- [Status Account Specification](status-account-spec.md). What a Status account is and how trust is established.
 
 ### Raw
 

--- a/status-account-spec.md
+++ b/status-account-spec.md
@@ -110,6 +110,7 @@ not do this.
 **Trust establishment deals with users verifying they are communicating with who they think they are.**
 
 ### Terms Glossary
+
 | term | description |
 | ---- | ----------- |
 | privkey | ECDSA secp256k1 private key |

--- a/status-account-spec.md
+++ b/status-account-spec.md
@@ -1,12 +1,14 @@
 # Status Account Specification
 
-> Version: 0.1 (Draft)
+> Version: 0.2
+> 
+> Status: Stable
 >
 > Authors: Corey Petty <corey@status.im>, Oskar Thorén <oskar@status.im> (alphabetical order)
 
 ## Abstract
 
-TBD.
+What a Status account is and how trust is established.
 
 ## Table of Contents
 
@@ -214,4 +216,4 @@ All messages sent are encrypted with the public key of the destination and signe
 
 ## Security Considerations
 
-TBD.
+-

--- a/status-account-spec.md
+++ b/status-account-spec.md
@@ -8,7 +8,7 @@
 
 ## Abstract
 
-What a Status account is and how trust is established.
+In this specification we explain what Status account is, and how trust is established.
 
 ## Table of Contents
 


### PR DESCRIPTION
This PR moves accounts spec from draft to stable. This means it is an accurate description of what is currently in production for the v1 app.

If we want to do wider changes in the future these should come in the form of SIP issues and PRs, as indicated in the README.

Changes to this spec can still occur but they should be cocsmetic ones, errata and clarifications.

Please review with anything factually incorrect or add any relevant data. I want to get this merged over the next 24-48h. This will ensure we have a stable set of specs that accurately reflects what is in production, and then we can proceed from there.