### PR TITLE
Added EmojiReaction payload types

### DIFF
--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -35,6 +35,8 @@ as various clients created using different technologies.
      - [Content types](#content-types)
        - [Sticker content type](#sticker-content-type)
        - [Image content type](#image-content-type)
+       - [EmojiReaction content type](#emojireaction-content-type)
+       - [EmojiReactionRetraction content type](#emojireactionretraction-content-type)
      - [Message types](#message-types)
      - [Clock vs Timestamp and message ordering](#clock-vs-timestamp-and-message-ordering)
      - [Chats](#chats)
@@ -109,6 +111,8 @@ message ChatMessage {
   oneof payload {
     StickerMessage sticker = 9;
     ImageMessage image = 10;
+    EmojiReaction emoji_reaction = 11;
+    EmojiReactionRetraction emoji_reaction_retraction = 12;
   }
 
   enum MessageType {
@@ -128,6 +132,8 @@ message ChatMessage {
     // Only local
     SYSTEM_MESSAGE_CONTENT_PRIVATE_GROUP = 6;
     IMAGE = 7;
+    EMOJI_REACTION = 8;
+    EMOJI_REACTION_RETRACTION = 9;
   }
 }
 ```
@@ -144,7 +150,7 @@ message ChatMessage {
 | 6 | chat_id | `string` | The local ID of the chat the message is sent to |
 | 7 | message_type | `MessageType` | The type of message, different for one-to-one, public or group chats |
 | 8 | content_type | `ContentType` | The type of the content of the message | 
-| 9 | payload | `Sticker|Image|nil` | The payload of the message based on the content type |
+| 9 | payload | `Sticker` I `Image` I `EmojiReaction` I `EmojiReactionRetraction` I `nil` | The payload of the message based on the content type |
 
 #### Content types
 
@@ -159,6 +165,8 @@ There are other content types that MAY be implemented by the client:
 * `EMOJI`
 * `TRANSACTION_COMMAND`
 * `IMAGE`
+* `EMOJI_REACTION`
+* `EMOJI_REACTION_RETRACTION`
 
 ##### Sticker content type
 
@@ -188,6 +196,49 @@ message ImageMessage {
     WEBP = 3;
     GIF = 4;
   }
+}
+```
+
+##### EmojiReaction content type
+
+`EmojiReaction`s represents a user's "reaction" to a specific chat message. For more information about the concept of
+emoji reactions see [Facebook Reactions](https://en.wikipedia.org/wiki/Facebook_like_button#Use_on_Facebook).
+
+This specification RECOMMENDS that the UI/UX implementation of sending `EmojiReactions` requires only a single click
+operation, as users have an expectation that emoji reactions are effortless and simple to perform.  
+
+A `ChatMessage` with `EMOJI_REACTION` `Content/Type` MUST also specify the `EmojiReaction` fields `message_id` and `type`
+
+```protobuf
+message EmojiReaction {
+  string message_id = 1;
+  Type type = 2;
+
+  enum Type {
+    UNKNOWN_EMOJI_REACTION_TYPE = 0;
+    LOVE = 1;
+    THUMBS_UP = 2;
+    THUMBS_DOWN = 3;
+    LAUGH = 4;
+    SAD = 5;
+    ANGRY = 6;
+  }
+}
+```
+
+#####  EmojiReactionRetraction content type
+
+`EmojiReactionRetraction`s represent a user removing a reaction, they previously performed, from a specific chat message.
+
+This specification RECOMMENDS that the UI/UX implementation of sending `EmojiReactionRetraction`s requires only a single
+click operation, as users have an expectation that emoji reaction removals are effortless and simple to perform.  
+
+A `ChatMessage` with `EMOJI_REACTION_RETRACTION` `Content/Type` MUST also specify the `EmojiReactionRetraction` field
+`emoji_reaction_id`
+
+```protobuf
+message EmojiReactionRetraction {
+  string emoji_reaction_id = 1;
 }
 ```
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -10,7 +10,7 @@ title: 6/PAYLOADS
 >
 > Status: Draft
 >
-> Authors: Adam Babik <adam@status.im>, Andrea Maria Piana <andreap@status.im>, Oskar Thorén <oskar@status.im> (alphabetical order)
+> Authors: Adam Babik <adam@status.im>, Andrea Maria Piana <andreap@status.im>, Oskar Thorén <oskar@status.im>, Samuel Hawksby-Robinson <samuel@status.im> (alphabetical order)
 
 ## Abstract
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -118,13 +118,6 @@ message ChatMessage {
     AudioMessage audio = 11;
   }
 
-  enum MessageType {
-    UNKNOWN_MESSAGE_TYPE = 0;
-    ONE_TO_ONE = 1;
-    PUBLIC_GROUP = 2;
-    PRIVATE_GROUP = 3;
-    // Only local
-    SYSTEM_MESSAGE_PRIVATE_GROUP = 4;}
   enum ContentType {
     UNKNOWN_CONTENT_TYPE = 0;
     TEXT_PLAIN = 1;
@@ -249,6 +242,17 @@ The following messages types MUST be supported:
 * `ONE_TO_ONE` is a message to the public group
 * `PUBLIC_GROUP` is a private message
 * `PRIVATE_GROUP` is a message to the private group.
+
+```protobuf
+  enum MessageType {
+    UNKNOWN_MESSAGE_TYPE = 0;
+    ONE_TO_ONE = 1;
+    PUBLIC_GROUP = 2;
+    PRIVATE_GROUP = 3;
+    // Only local
+    SYSTEM_MESSAGE_PRIVATE_GROUP = 4;
+}
+```
 
 #### Clock vs Timestamp and message ordering
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -10,7 +10,7 @@ title: 6/PAYLOADS
 >
 > Status: Draft
 >
-> Authors: Adam Babik <adam@status.im>, Andrea Maria Piana <andreap@status.im>, Oskar Thorén <oskar@status.im> (alphabetical order)
+> Authors: Adam Babik <adam@status.im>, Andrea Maria Piana <andreap@status.im>, Oskar Thorén <oskar@status.im>, Samuel Hawksby-Robinson <samuel@status.im> (alphabetical order)
 
 ## Abstract
 
@@ -42,6 +42,7 @@ as various clients created using different technologies.
    - [Contact Update](#contact-update)
      - [Payload](#payload-2)
      - [Contact update](#contact-update-1)
+   - [EmojiReaction](#emojireaction)
    - [SyncInstallationContact](#syncinstallationcontact)
      - [Payload](#payload-3)
    - [SyncInstallationPublicChat](#syncinstallationpublicchat)
@@ -235,9 +236,8 @@ message AudioMessage {
     UNKNOWN_AUDIO_TYPE = 0;
     AAC = 1;
     AMR = 2;
-  }
-}
-```
+
+
 
 #### Message types
 
@@ -315,6 +315,52 @@ A client SHOULD send a `ContactUpdate` to all the contacts each time:
 - A user edits the profile image
 
 A client SHOULD also periodically send a `ContactUpdate` to all the contacts, the interval is up to the client, the Status official client sends these updates every 48 hours.
+
+### EmojiReaction
+
+`EmojiReaction`s represents a user's "reaction" to a specific chat message. For more information about the concept of
+emoji reactions see [Facebook Reactions](https://en.wikipedia.org/wiki/Facebook_like_button#Use_on_Facebook).
+
+This specification RECOMMENDS that the UI/UX implementation of sending `EmojiReactions` requires only a single click
+operation, as users have an expectation that emoji reactions are effortless and simple to perform.  
+
+```protobuf
+message EmojiReaction {
+  // clock Lamport timestamp of the chat message
+  uint64 clock = 1;
+
+  // chat_id the ID of the chat the message belongs to, for query efficiency the chat_id is stored in the db even though the
+  // target message also stores the chat_id
+  string chat_id = 2;
+
+  // message_id the ID of the target message that the user wishes to react to
+  string message_id = 3;
+
+  // message_type is (somewhat confusingly) the ID of the type of chat the message belongs to
+  MessageType message_type = 4;
+
+  // type the ID of the emoji the user wishes to react with
+  Type type = 5;
+
+  enum Type {
+    UNKNOWN_EMOJI_REACTION_TYPE = 0;
+    LOVE = 1;
+    THUMBS_UP = 2;
+    THUMBS_DOWN = 3;
+    LAUGH = 4;
+    SAD = 5;
+    ANGRY = 6;
+  }
+
+ // whether this is a retraction of a previously sent emoji
+  bool retracted = 6;
+}
+```
+
+Clients MUST specify `clock`, `chat_id`, `message_id`, `type` and `message_type`.
+
+This specification RECOMMENDS that the UI/UX implementation of retracting an `EmojiReaction`s requires only a single
+click operation, as users have an expectation that emoji reaction removals are effortless and simple to perform.  
 
 ### SyncInstallationContact
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -1,6 +1,9 @@
 Ack
 activePublicKey
 ACL
+AAC
+AMR
+AudioType
 AES
 APIs
 APN
@@ -15,6 +18,7 @@ BIP
 BIPs
 blockable
 boolean
+bool
 BlockByHash
 BlockByNumber
 blockchain
@@ -74,6 +78,8 @@ EE
 Eigenmann
 EIP
 EIPs
+EmojiReaction
+EmojiReactionRetraction
 EncodeToString
 enode
 enr
@@ -215,6 +221,7 @@ requestMessages
 RLP
 RLPx
 RPC
+retraction
 scalability
 scalable
 secp

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -73,6 +73,8 @@ EE
 Eigenmann
 EIP
 EIPs
+EmojiReaction
+EmojiReactionRetraction
 EncodeToString
 enode
 enr


### PR DESCRIPTION
Added emoji reaction payload specifications.

For reference see:

- [`status-go` implementation](https://github.com/status-im/status-go/pull/1999)
- [`status-react` implementation](https://github.com/status-im/status-react/pull/10912)
- [UI process flows](https://www.figma.com/file/aS1ct66VQ6V0cio7vSqS8UoG/Chat?node-id=1239%3A0)

I've added these specs to the draft version of `6-payloads` because I saw images in drafts and presumed that emoji reactions would also be considered on the same level or lower of spec stability.