### PR TITLE
Introduction of ChatIdentity

### DIFF
--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -261,7 +261,7 @@ message is supposed to be displayed last in a chat. This is where the basic algo
 as it's only meant to order causally related events.
 
 The status client therefore makes a "bid", speculating that it will beat the current chat-timestamp, s.t. the status client's
-Lamport timestamp format is: `clock = `max({timestamp}, chat_clock + 1)`
+Lamport timestamp format is: `clock = max({timestamp}, chat_clock + 1)`
 
 This will satisfy the Lamport requirement, namely: a -> b then T(a) < T(b)
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -307,11 +307,11 @@ The `ProfileImage` data struct describes the mechanisms by which the application
 
 The main components of the `ProfileImage` are:
 
-| Field name      | Description |
-| --------------- |---|
-| `payload` | A context based payload for the profile image data. Context is determined by the `source_type` |
+| Field name    | Description |
+| ------------- |---|
+| `payload`     | A context based payload for the profile image data. Context is determined by the `source_type` |
 | `source_type` | A `SourceType` enum, signals the image payload source |
-| `image_type` | An `ImageType` enum, signals the image type and method of parsing the payload |
+| `image_type`  | An `ImageType` enum, signals the image type and method of parsing the payload |
 
 #### Payload
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -295,11 +295,11 @@ The `ChatMessageIdentity` allows a user to OPTIONALLY broadcast an identity to b
 
 The main components of the `ChatMessageIdentity` are:
 
-| Field name      | Description |
-| --------------- |---|
-| `ens_name`      | A valid registered ENS name for the user. Deprecates the `ens_name` field in `ChatMessage` |
-| `display_name`  | A user determined display name not requiring blockchain registry |
-| `profile_image` | A `ProfileImage` data struct used to transmit user profile image data |
+| Field | Name            | Type           | Description |
+| ----- | --------------- | -------------- | --- |
+| 2     | `ens_name`      | `string`       | A valid registered ENS name for the user. Deprecates the `ens_name` field in `ChatMessage` |
+| 3     | `display_name`  | `string`       | A user determined display name not requiring blockchain registry |
+| 4     | `profile_image` | `ProfileImage` | A data struct used to transmit user profile image data |
 
 #### Profile Image
 
@@ -307,11 +307,11 @@ The `ProfileImage` data struct describes the mechanisms by which the application
 
 The main components of the `ProfileImage` are:
 
-| Field name    | Description |
-| ------------- |---|
-| `payload`     | A context based payload for the profile image data. Context is determined by the `source_type` |
-| `source_type` | A `SourceType` enum, signals the image payload source |
-| `image_type`  | An `ImageType` enum, signals the image type and method of parsing the payload |
+| Field | Name          | Type         | Description |
+| ----- | ------------- | ------------ | --- |
+| 1     | `payload`     | `string`     | A context based payload for the profile image data. Context is determined by the `source_type` |
+| 2     | `source_type` | `SourceType` | Enum, signals the image payload source |
+| 3     | `image_type`  | `ImageType`  | Enum, signals the image type and method of parsing the payload |
 
 #### Payload
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -411,6 +411,8 @@ This specification RECOMMENDS that the application only sends one `IdentityUpdat
 
 To preserve the privacy of the user, the `ProfileImage.payload` or ENS `get-text-data.avatar` field SHOULD NOT be or be parsed as a URL, an IPFS address or an IPNS address. Malicious actors could set their payload to an image URL and force all users that parse their `ProfileImage.payload` and log the IP address of users of selected topics.
 
+An additional step to maintaining user privacy is to adhere to the `IdentityUpdate` event triggering, `IdentityUpdate` MUST only be sent after a user sends a `ChatMessage` to a topic. This will ensure that users who wish to only read topic messages do not "leak" their identity data into topics they have not actively participated in. 
+
 ### Contact Update
 
 `ContactUpdate` is a message exchange to notify peers that either the

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -39,7 +39,7 @@ as various clients created using different technologies.
      - [Message types](#message-types)
      - [Clock vs Timestamp and message ordering](#clock-vs-timestamp-and-message-ordering)
      - [Chats](#chats)
-   - [Chat Message Identity](#chat-message-identity)
+   - [Chat Identity](#chat-identity)
    - [Contact Update](#contact-update)
      - [Payload](#payload-2)
      - [Contact update](#contact-update-1)
@@ -51,6 +51,8 @@ as various clients created using different technologies.
    - [PairInstallation](#pairinstallation)
      - [Payload](#payload-5)
    - [MembershipUpdateMessage and MembershipUpdateEvent](#membershipupdatemessage-and-membershipupdateevent)
+ - [Enums](#enums)
+   - [ImageType](#imagetype)
  - [Upgradability](#upgradability)
  - [Security Considerations](#security-considerations)
  - [Changelog](#changelog)
@@ -187,7 +189,7 @@ message StickerMessage {
 ##### Image content type
 
 A `ChatMessage` with `IMAGE` `Content/Type` MUST also specify the `payload` of the image
-and the `type`.
+and the `type`. Also see [ImageType](#imagetype)
 
 Clients MUST sanitize the payload before accessing its content, in particular: 
 - Clients MUST choose a secure decoder
@@ -306,7 +308,7 @@ The main components of the `ProfileImage` are:
 | ----- | ------------- | ------------------ | --- |
 | 1     | `payload`     | `bytes`            | A context based payload for the profile image data. Context is determined by the `source_type` |
 | 2     | `source_type` | `SourceType`       | Enum, signals the image payload source |
-| 3     | `image_type`  | `enums.ImageType`  | Enum, signals the image type and method of parsing the payload |
+| 3     | `image_type`  | `enums.ImageType`  | Enum, signals the image type and method of parsing the payload. See [ImageType](#imagetype) |
 
 #### Payload
 
@@ -536,6 +538,28 @@ message PairInstallation {
 
 `MembershipUpdateEvent` is a message used to propagate information about group membership changes in a group chat.
 The details are in the [Group chats specs](./7-group-chat.md).
+
+## Enums
+
+### ImageType
+
+```protobuf
+enum ImageType {
+  UNKNOWN_IMAGE_TYPE = 0;
+
+  // Raster image files is payload data that can be read as a raster image
+  PNG = 1;
+  JPEG = 2;
+  WEBP = 3;
+  GIF = 4;
+
+  // Vector image files is payload data that can be interpreted as a vector image
+  SVG = 101;
+
+  // AVATAR is payload data that can be parsed as avatar compilation instructions
+  AVATAR = 201;
+}
+```
 
 ## Upgradability
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -572,7 +572,8 @@ There are two ways to upgrade the protocol without breaking compatibility:
 
 Released //TODO
 
-- Added Chat Identity payload
+- Added `ChatMessageIdentity` payload
+- Marks `ChatMessage.ens_name` as DEPRECATED
 
 ### Version 0.5
 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -144,7 +144,7 @@ message ChatMessage {
 | 2 | timestamp | `uint64` | The sender timestamp at message creation |
 | 3 | text | `string` | The content of the message |
 | 4 | response_to | `string` | The ID of the message replied to |
-| 5 | ens_name | `string` | DEPRECATED - [See Chat Message Identity](#chat-message-identity). The ENS name of the user sending the message |
+| 5 | ens_name | `string` | DEPRECATED - [See Chat Identity](#chat-identity). The ENS name of the user sending the message |
 | 6 | chat_id | `string` | The local ID of the chat the message is sent to |
 | 7 | message_type | `MessageType` | The type of message, different for one-to-one, public or group chats |
 | 8 | content_type | `ContentType` | The type of the content of the message | 

--- a/docs/draft/6-payloads.md
+++ b/docs/draft/6-payloads.md
@@ -383,6 +383,10 @@ message ProfileImage {
 
 #### Implementation Recommendations
 
+##### ChatMessage ens_name
+
+The application MUST handle `ChatMessage.ens_name` as well as `ChatMessageIdentity.ens_name` to maintain backwards compatibility. The `ChatMessage.ens_name` field has been marked as DEPRECATED in this version of the specification to highlight that this field should be removed as part of any upgrade to a major version. 
+
 ##### Identity Update
 
 An `IdentityUpdate` is a concept representing the event of the application sending a `ChatMessageIdentity` in response to either:
@@ -397,11 +401,11 @@ This specification RECOMMENDS that the application only sends one `IdentityUpdat
 
 ##### Private Group Chat
 
-This specification RECOMMENDS that the application only sends one `IdentityUpdate`, with not `ChatMessageIdentity TTL`, and once per new user joining the chat group.
+This specification RECOMMENDS that the application only sends one `IdentityUpdate`, with no `ChatMessageIdentity TTL`, and once per new user joining the chat group.
 
 ##### Public Chat
 
- This specification RECOMMENDS that the application only sends one `IdentityUpdate`, with a `ChatMessageIdentity TTL` of 24 hours. 
+This specification RECOMMENDS that the application only sends one `IdentityUpdate`, with a `ChatMessageIdentity TTL` of 24 hours. 
 
 ##### Security
 

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -30,6 +30,7 @@ Changelog
 chatId
 chatID
 chatid
+ChatIdentity
 ChatMessage
 ChatMessageIdentity
 contactCode
@@ -121,6 +122,7 @@ html
 http
 HTTPS
 identicon
+IdentityImage
 IK
 im
 ImageMessage
@@ -146,6 +148,7 @@ keypair
 keypairs
 Kozieiev
 Lamport
+lamport
 legislations
 len
 libp

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -32,7 +32,6 @@ chatID
 chatid
 ChatIdentity
 ChatMessage
-ChatMessageIdentity
 contactCode
 contactcode
 ContactCodeAdvertisement
@@ -87,6 +86,7 @@ EncodeToString
 enode
 enr
 enum
+Enums
 exif
 ERC
 ErrorType
@@ -193,6 +193,7 @@ pin
 Pinzaru
 plaintext
 Pluggable
+PNG
 Pombeiro
 PoW
 pre
@@ -255,6 +256,7 @@ suboptimal
 subprotocol
 subprotocols
 SuggestGasPrice
+SVG
 SyncInstallationContact
 SyncInstallationPublicChat
 TCP
@@ -291,6 +293,7 @@ Waku
 Waku's
 waku
 wakuext
+WEBP
 webview
 Webview
 wei

--- a/wordlist.txt
+++ b/wordlist.txt
@@ -31,6 +31,7 @@ chatId
 chatID
 chatid
 ChatMessage
+ChatMessageIdentity
 contactCode
 contactcode
 ContactCodeAdvertisement
@@ -123,10 +124,12 @@ identicon
 IK
 im
 ImageMessage
+ImageType
 ImportECDSA
 ImportECDSAPublic
 infura
 IPFS
+IPNS
 IPs
 Iubenda
 Jacek
@@ -196,6 +199,8 @@ prepend
 prepended
 prepending
 privkey
+ProfileImage
+proto
 protobuf
 ProtocolMessage
 PSS
@@ -237,10 +242,12 @@ SIP
 SIPs
 SNT
 Sourcecode
+SourceType
 SPK
 StickerMessage
 stickerpack
 strconv
+struct
 suboptimal
 subprotocol
 subprotocols


### PR DESCRIPTION
## What has changed?

I've introduced the payload type of `ChatMessageIdentity`. This payload type will be used to optionally broadcast user determined identity data about the user.

The immediate use case of the `ChatMessageIdentity` is user determined profile images and display names.

Additionally the change marks `ChatMessage.ens_name` field as deprecated, `ens_name` will become part of the `ChatMessageIdentity`.

## Why make the change?

User's want to be able to have user determined identity. User's want the option to overwrite the default "3 word name" and identicon with a representation that they have control over.

## Note

The use of `ChatMessageIdentity` is 100% optional and users may choose not use any part of the `ChatMessageIdentity` and therefore default to the "3 word name" and identicon.

Also see:

- [Profile image `epic`](https://github.com/status-im/status-react/issues/11047)
- [Avatar discuss post](https://discuss.status.im/t/profile-avatars-an-exploration/1948)