### PR TITLE
Fix broken links to vacp2p specs

### DIFF
--- a/docs/stable/1-client.md
+++ b/docs/stable/1-client.md
@@ -99,7 +99,7 @@ allows for TCP-based communication between nodes.
 
 On top of this RLPx-based subprotocols are ran, the client
 SHOULD NOT use [Whisper V6](https://eips.ethereum.org/EIPS/eip-627), the client 
-SHOULD use [Waku V1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md)
+SHOULD use [Waku V1](https://rfc.vac.dev/spec/6/)
 for privacy-preserving messaging and efficient usage of a node's bandwidth.
 
 #### Node discovery and roles
@@ -276,7 +276,7 @@ computer.
 #### Why do you use Waku?
 
 Waku is a direct upgrade and replacement for Whisper, the main motivation for 
-developing and implementing Waku can be found in the [Waku specs](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#motivation).
+developing and implementing Waku can be found in the [Waku specs](https://rfc.vac.dev/spec/6/#motivation).
 
 >Waku was created to incrementally improve in areas that Whisper is lacking in, 
 >with special attention to resource restricted devices. We specify the standard for 

--- a/docs/stable/10-waku-usage.md
+++ b/docs/stable/10-waku-usage.md
@@ -36,7 +36,7 @@ title: 10/WAKU-USAGE
 
 ## Abstract
 
-Status uses [Waku](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md) to provide
+Status uses [Waku](https://rfc.vac.dev/spec/6/) to provide
 privacy-preserving routing and messaging on top of devP2P. Waku uses topics
 to partition its messages, and these are leveraged for all chat capabilities. In
 the case of public chats, the channel name maps directly to its Waku topic.
@@ -63,14 +63,14 @@ encryption properties to support asynchronous chat.
 
 | Packet Name          | Code | References |
 | -------------------- | ---: | --- |
-| Status               |    0 | [Status](#status), [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#status) |
-| Messages             |    1 | [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#messages) |
+| Status               |    0 | [Status](#status), [WAKU-1](https://rfc.vac.dev/spec/6/#status) |
+| Messages             |    1 | [WAKU-1](https://rfc.vac.dev/spec/6/#messages) |
 | Batch Ack            |   11 | Undocumented. Marked for Deprecation |
-| Message Response     |   12 | [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#message-confirmations-update) |
-| Status Update        |   22 | [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#status-update) |
+| Message Response     |   12 | [WAKU-1](https://rfc.vac.dev/spec/6/#batch-ack-and-message-response) |
+| Status Update        |   22 | [WAKU-1](https://rfc.vac.dev/spec/6/#status-update) |
 | P2P Request Complete |  125 | [4/WAKU-MAILSERVER](https://specs.status.im/spec/4) |
-| P2P Request          |  126 | [4/WAKU-MAILSERVER](https://specs.status.im/spec/4), [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#p2p-request) |
-| P2P Messages         |  127 | [4/WAKU-MAILSERVER](https://specs.status.im/spec/4), [WAKU-1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#p2p-message) |
+| P2P Request          |  126 | [4/WAKU-MAILSERVER](https://specs.status.im/spec/4), [WAKU-1](https://rfc.vac.dev/spec/6/#p2p-request) |
+| P2P Messages         |  127 | [4/WAKU-MAILSERVER](https://specs.status.im/spec/4), [WAKU-1](https://rfc.vac.dev/spec/6/#p2p-request-complete) |
 
 ## Waku node configuration
 
@@ -97,12 +97,12 @@ Handshake is a RLP-encoded packet sent to a newly connected peer. It MUST start 
 
 | Option Name             | Key    | Type     | Description | References |
 | ----------------------- | ------ | -------- | ----------- | --- |
-| `pow-requirement`       | `0x00` | `uint64` | minimum PoW accepted by the peer | [WAKU-1#pow-requirement](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#pow-requirement-field) |
-| `bloom-filter`          | `0x01` | `[]byte` | bloom filter of Waku topic accepted by the peer | [WAKU-1#bloom-filter](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#bloom-filter-field) |
-| `light-node`            | `0x02` | `bool`   | when true, the peer won't forward envelopes through the Messages packet. | `TODO` |
-| `confirmations-enabled` | `0x03` | `bool`   | when true, the peer will send message confirmations | `TODO` |
-| `rate-limits`           | `0x04` |          | See [Rate limiting](#rate-limiting) | [WAKU-1#rate-limits](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#rate-limits-field) |
-| `topic-interest`        | `0x05` | `[10000][4]byte` | Topic interest is used to share a node's interest in envelopes with specific topics. It does this in a more bandwidth considerate way, at the expense of some metadata protection. Peers MUST only send envelopes with specified topics. | [WAKU-1#topic-interest](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#topic-interest-field), [the theoretical scaling model](https://github.com/vacp2p/research/tree/dcc71f4779be832d3b5ece9c4e11f1f7ec24aac2/whisper_scalability) |
+| `pow-requirement`       | `0x00` | `uint64` | minimum PoW accepted by the peer | [WAKU-1#pow-requirement](https://rfc.vac.dev/spec/6/#pow-requirement-field) |
+| `bloom-filter`          | `0x01` | `[]byte` | bloom filter of Waku topic accepted by the peer | [WAKU-1#bloom-filter](https://rfc.vac.dev/spec/6/#bloom-filter-field) |
+| `light-node`            | `0x02` | `bool`   | when true, the peer won't forward envelopes through the Messages packet. | [WAKU-1#light-node](https://rfc.vac.dev/spec/6/#light-node) |
+| `confirmations-enabled` | `0x03` | `bool`   | when true, the peer will send message confirmations | [WAKU-1#confirmations-enabled-field](https://rfc.vac.dev/spec/6/#confirmations-enabled-field) |
+| `rate-limits`           | `0x04` |          | See [Rate limiting](#rate-limiting) | [WAKU-1#rate-limits](https://rfc.vac.dev/spec/6/#rate-limits-field) |
+| `topic-interest`        | `0x05` | `[10000][4]byte` | Topic interest is used to share a node's interest in envelopes with specific topics. It does this in a more bandwidth considerate way, at the expense of some metadata protection. Peers MUST only send envelopes with specified topics. | [WAKU-1#topic-interest](https://rfc.vac.dev/spec/6/#topic-interest-field), [the theoretical scaling model](https://github.com/vacp2p/research/tree/dcc71f4779be832d3b5ece9c4e11f1f7ec24aac2/whisper_scalability) |
 
 <!-- TODO Add `light-node` and `confirmations-enabled` links when https://github.com/vacp2p/specs/pull/128 is merged -->
 

--- a/docs/stable/3-whisper-usage.md
+++ b/docs/stable/3-whisper-usage.md
@@ -317,12 +317,12 @@ In order to maintain compatibility between Whisper and Waku nodes, a Status netw
 implements both Whisper and Waku messaging protocols MUST have at least one node that is
 capable of discovering peers and implements
 [Whisper v6](https://eips.ethereum.org/EIPS/eip-627),
-[Waku V0](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-0.md) and
-[Waku V1](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md) specifications.
+[Waku V0](https://rfc.vac.dev/spec/5/) and
+[Waku V1](https://rfc.vac.dev/spec/6/) specifications.
 
 Additionally, any Status network that implements both Whisper and Waku messaging protocols
 MUST implement bridging capabilities as detailed in
-[Waku V1#Bridging](https://github.com/vacp2p/specs/blob/master/specs/waku/waku-1.md#waku-whisper-bridging).  
+[Waku V1#Bridging](https://rfc.vac.dev/spec/6/#waku-whisper-bridging).  
 
 ## Whisper V6 extensions
 


### PR DESCRIPTION
Fixes several broken links to vacp2p specs in the stable Status specifications.

cc @iurimatias 