### PR TITLE
Fix development docs to use correct bin path for ruby gems

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -19,7 +19,7 @@ gem install jekyll bundler
 It might be necessary to specify installation destination for your Gems:
 ```
 export GEM_HOME="$HOME/.gems"
-export PATH="$HOME/gems/bin:$PATH"
+export PATH="$GEM_HOME/bin:$PATH"
 ```
 For instructions on other systems use [these docs](https://jekyllrb.com/docs/installation/).
 


### PR DESCRIPTION
Seems like there was a typo in the `PATH` declaration for installed
ruby gem binaries. This causes installed gems to be found.

This commit fixes it by reusing the `GEM_HOME` var so `PATH`
will use `.gems` (not `gems`) as well.